### PR TITLE
Removes use_sim_time param from yaml

### DIFF
--- a/kimchi_navigation/params/nav2_params.yaml
+++ b/kimchi_navigation/params/nav2_params.yaml
@@ -1,6 +1,5 @@
 amcl:
   ros__parameters:
-    use_sim_time: True
     alpha1: 0.2
     alpha2: 0.2
     alpha3: 0.2
@@ -48,7 +47,6 @@ amcl:
 
 bt_navigator:
   ros__parameters:
-    use_sim_time: True
     global_frame: map
     robot_base_frame: base_link
     odom_topic: /odom
@@ -75,7 +73,6 @@ bt_navigator:
 
 controller_server:
   ros__parameters:
-    use_sim_time: True
     controller_frequency: 10.0
     min_x_velocity_threshold: 0.001
     min_y_velocity_threshold: 0.5
@@ -207,7 +204,6 @@ controller_server:
 local_costmap:
   local_costmap:
     ros__parameters:
-      use_sim_time: True
       update_frequency: 5.0
       publish_frequency: 2.0
       global_frame: odom
@@ -250,7 +246,6 @@ local_costmap:
 global_costmap:
   global_costmap:
     ros__parameters:
-      use_sim_time: True
       update_frequency: 1.0
       publish_frequency: 1.0
       global_frame: map
@@ -291,7 +286,6 @@ global_costmap:
 
 map_saver:
   ros__parameters:
-    use_sim_time: True
     save_map_timeout: 5.0
     free_thresh_default: 0.25
     occupied_thresh_default: 0.65
@@ -299,7 +293,6 @@ map_saver:
 
 planner_server:
   ros__parameters:
-    use_sim_time: True
     expected_planner_frequency: 10.0
     planner_plugins: ["GridBased"]
     costmap_update_timeout: 1.0
@@ -337,7 +330,6 @@ planner_server:
 
 smoother_server:
   ros__parameters:
-    use_sim_time: True
     smoother_plugins: ["simple_smoother"]
     simple_smoother:
       plugin: "nav2_smoother::SimpleSmoother"
@@ -347,7 +339,6 @@ smoother_server:
 
 behavior_server:
   ros__parameters:
-    use_sim_time: True
     local_costmap_topic: local_costmap/costmap_raw
     global_costmap_topic: global_costmap/costmap_raw
     local_footprint_topic: local_costmap/published_footprint
@@ -374,7 +365,6 @@ behavior_server:
 
 waypoint_follower:
   ros__parameters:
-    use_sim_time: True
     loop_rate: 10
     stop_on_failure: false
     action_server_result_timeout: 900.0
@@ -386,7 +376,6 @@ waypoint_follower:
 
 velocity_smoother:
   ros__parameters:
-    use_sim_time: True
     smoothing_frequency: 10.0
     scale_velocities: False
     feedback: "OPEN_LOOP"
@@ -490,7 +479,3 @@ loopback_simulator:
     map_frame_id: "map"
     scan_frame_id: "base_scan"  # tb4_loopback_simulator.launch.py remaps to 'rplidar_link'
     update_duration: 0.02
-
-robot_state_publisher:
-  ros__parameters:
-    use_sim_time: True


### PR DESCRIPTION
Setting `use_sim_time' to true is overriding the variable set in the launch file. That is what the costmap was not shown in rviz.