### PR TITLE
Add bumper behavior

### DIFF
--- a/kimchi_base/include/kimchi_base/diffdrive_kimchi.h
+++ b/kimchi_base/include/kimchi_base/diffdrive_kimchi.h
@@ -72,6 +72,9 @@ class DiffDriveKimchi : public hardware_interface::SystemInterface {
  private:
   const std::string kLeftWheelNameParam{"left_wheel_name"};
   const std::string kRightWheelNameParam{"right_wheel_name"};
+  const std::string kLeftBumperNameParam{"left_bumper_name"};
+  const std::string kRightBumperNameParam{"right_bumper_name"};
+  const std::string kButtonNameParam{"button_name"};
   const std::string kSerialDeviceParam{"serial_device"};
   const std::string kBaudRateParam{"baud_rate"};
   const std::string kTimeoutParam{"timeout"};
@@ -82,6 +85,10 @@ class DiffDriveKimchi : public hardware_interface::SystemInterface {
     // Name of the left and right wheels.
     std::string left_wheel_name = "left_wheel";
     std::string right_wheel_name = "right_wheel";
+    // Name of the left and right bumpers and button.
+    std::string left_bumper_name = "left_bumper";
+    std::string right_bumper_name = "right_bumper";
+    std::string button_name = "button";
     // Encoder parameters.
     int enc_ticks_per_rev = 960;
     // Communication parameters.
@@ -98,6 +105,10 @@ class DiffDriveKimchi : public hardware_interface::SystemInterface {
   Wheel left_wheel_;
   // Right wheel of the robot.
   Wheel right_wheel_;
+  // Bumper and button values.
+  double left_bumper_{0.0}
+  double right_bumper_{0.0}
+  double button_{0.0}
   // Logger.
   rclcpp::Logger logger_{rclcpp::get_logger("DiffDriveKimchi")};
 };

--- a/kimchi_base/include/kimchi_base/diffdrive_kimchi.h
+++ b/kimchi_base/include/kimchi_base/diffdrive_kimchi.h
@@ -106,9 +106,9 @@ class DiffDriveKimchi : public hardware_interface::SystemInterface {
   // Right wheel of the robot.
   Wheel right_wheel_;
   // Bumper and button values.
-  double left_bumper_{0.0}
-  double right_bumper_{0.0}
-  double button_{0.0}
+  double left_bumper_{0.0};
+  double right_bumper_{0.0};
+  double button_{0.0};
   // Logger.
   rclcpp::Logger logger_{rclcpp::get_logger("DiffDriveKimchi")};
 };

--- a/kimchi_base/include/kimchi_base/motor_driver.h
+++ b/kimchi_base/include/kimchi_base/motor_driver.h
@@ -46,8 +46,9 @@ namespace kimchi_base {
 /// 3. Use api to send commands to the motor driver.
 class MotorDriver {
  public:
-  /// @brief Type to store the encoder values.
-  using Encoders = std::array<int, 2>;
+  /// @brief Type to store the hardware data read from the Arduino.
+  /// It contains the left encoder value, right encoder value, left bumper value, right bumper values and button value.
+  using HardwareData = std::array<int, 5>;
 
   /// @brief Default constructor.
   MotorDriver() = default;
@@ -65,8 +66,8 @@ class MotorDriver {
   /// @brief Read the encoder values from the motor driver.
   ///       First value is the left encoder, second value is the right encoder.
   /// @returns The encoder values.
-  // Encoders ReadEncoderValues();
-  std::optional<Encoders> ReadEncoderValues();
+  // HardwareData ReadHardwareData();
+  std::optional<HardwareData> ReadHardwareData();
 
   /// @brief Set the motor values.
   ///        The unit of the values is in encoder ticks per revolution.

--- a/kimchi_base/include/kimchi_base/motor_driver.h
+++ b/kimchi_base/include/kimchi_base/motor_driver.h
@@ -47,7 +47,12 @@ namespace kimchi_base {
 class MotorDriver {
  public:
   /// @brief Type to store the hardware data read from the Arduino.
-  /// It contains the left encoder value, right encoder value, left bumper value, right bumper values and button value.
+  /// Fixed array indices for hardware values:
+  /// Index [0]: Left encoder value
+  /// Index [1]: Right encoder value
+  /// Index [2]: Left bumper value   (0 = not pressed, 1 = pressed)
+  /// Index [3]: Right bumper value  (0 = not pressed, 1 = pressed)
+  /// Index [4]: Button value        (0 = not pressed, 1 = pressed)
   using HardwareData = std::array<int, 5>;
 
   /// @brief Default constructor.

--- a/kimchi_base/src/diffdrive_kimchi.cpp
+++ b/kimchi_base/src/diffdrive_kimchi.cpp
@@ -43,10 +43,21 @@ hardware_interface::CallbackReturn DiffDriveKimchi::on_init(const hardware_inter
 
   RCLCPP_INFO(logger_, "On init...");
 
+  // Wheel names.
   config_.left_wheel_name = info_.hardware_parameters[kLeftWheelNameParam];
   RCLCPP_DEBUG(logger_, (kLeftWheelNameParam + static_cast<std::string>(": ") + config_.left_wheel_name).c_str());
   config_.right_wheel_name = info_.hardware_parameters[kRightWheelNameParam];
   RCLCPP_DEBUG(logger_, (kRightWheelNameParam + static_cast<std::string>(": ") + config_.right_wheel_name).c_str());
+
+  // Bumper and button names.
+  config_.left_bumper_name = info_.hardware_parameters[kLeftBumperNameParam];
+  RCLCPP_DEBUG(logger_, (kLeftBumperNameParam + static_cast<std::string>(": ") + config_.left_bumper_name).c_str());
+  config_.right_bumper_name = info_.hardware_parameters[kRightBumperNameParam];
+  RCLCPP_DEBUG(logger_, (kRightBumperNameParam + static_cast<std::string>(": ") + config_.right_bumper_name).c_str());
+  config_.button_name = info_.hardware_parameters[kButtonNameParam];
+  RCLCPP_DEBUG(logger_, (kButtonNameParam + static_cast<std::string>(": ") + config_.button_name).c_str());
+
+  // Serial communication parameters.
   config_.serial_device = info_.hardware_parameters[kSerialDeviceParam];
   RCLCPP_DEBUG(logger_, (kSerialDeviceParam + static_cast<std::string>(": ") + config_.serial_device).c_str());
   config_.baud_rate = std::stoi(info_.hardware_parameters[kBaudRateParam]);
@@ -61,15 +72,25 @@ hardware_interface::CallbackReturn DiffDriveKimchi::on_init(const hardware_inter
                    .c_str());
 
   for (const hardware_interface::ComponentInfo& joint : info.joints) {
-    // DiffDriveKimchi has exactly two states and one command interface on each joint
-    if (joint.command_interfaces.size() != 1) {
-      RCLCPP_FATAL(logger_, "Joint '%s' has %zu command interfaces found. 1 expected.", joint.name.c_str(),
-                   joint.command_interfaces.size());
+    bool is_wheel = (joint.name.find("wheel") != std::string::npos);
+
+    // Set expected interface counts based on joint type.
+    // Wheels have 1 command interface (velocity) and 2 state interfaces (position and velocity).
+    // Bumpers and button have no command interfaces and only 1 state interfaces (position).
+    size_t expected_command_interfaces = is_wheel ? 1 : 0;
+    size_t expected_state_interfaces = is_wheel ? 2 : 1;
+
+    // Validate command interfaces
+    if (joint.command_interfaces.size() != expected_command_interfaces) {
+      RCLCPP_FATAL(logger_, "Joint '%s' has %zu command interfaces found. %zu expected.", joint.name.c_str(),
+                   joint.command_interfaces.size(), expected_command_interfaces);
       return hardware_interface::CallbackReturn::ERROR;
     }
-    if (joint.state_interfaces.size() != 2) {
-      RCLCPP_FATAL(logger_, "Joint '%s' has %zu state interfaces found. 1 expected.", joint.name.c_str(),
-                   joint.state_interfaces.size());
+
+    // Validate state interfaces
+    if (joint.state_interfaces.size() != expected_state_interfaces) {
+      RCLCPP_FATAL(logger_, "Joint '%s' has %zu state interfaces found. %zu expected.", joint.name.c_str(),
+                   joint.state_interfaces.size(), expected_state_interfaces);
       return hardware_interface::CallbackReturn::ERROR;
     }
   }
@@ -98,8 +119,7 @@ std::vector<hardware_interface::StateInterface> DiffDriveKimchi::export_state_in
   // We need to set up a position and a velocity interface for each wheel
   std::vector<hardware_interface::StateInterface> state_interfaces;
 
-  // TODO(francocipollone): Probably we could use the information obtained via info_ variable about the joint name
-  // directly.
+  // Add left and right wheel interfaces
   state_interfaces.emplace_back(
       hardware_interface::StateInterface(left_wheel_.name_, hardware_interface::HW_IF_VELOCITY, &left_wheel_.vel_));
   state_interfaces.emplace_back(
@@ -108,6 +128,14 @@ std::vector<hardware_interface::StateInterface> DiffDriveKimchi::export_state_in
       hardware_interface::StateInterface(right_wheel_.name_, hardware_interface::HW_IF_VELOCITY, &right_wheel_.vel_));
   state_interfaces.emplace_back(
       hardware_interface::StateInterface(right_wheel_.name_, hardware_interface::HW_IF_POSITION, &right_wheel_.pos_));
+
+  // Add bumper and button interfaces
+  state_interfaces.emplace_back(
+      hardware_interface::StateInterface(config_.left_bumper_name, hardware_interface::HW_IF_POSITION, &left_bumper_));
+  state_interfaces.emplace_back(hardware_interface::StateInterface(config_.right_bumper_name,
+                                                                   hardware_interface::HW_IF_POSITION, &right_bumper_));
+  state_interfaces.emplace_back(
+      hardware_interface::StateInterface(config_.button_name, hardware_interface::HW_IF_POSITION, &button_));
 
   return state_interfaces;
 }
@@ -147,13 +175,17 @@ hardware_interface::return_type DiffDriveKimchi::read(const rclcpp::Time& /* tim
     return hardware_interface::return_type::ERROR;
   }
 
-  // const MotorDriver::Encoders encoders = motor_driver_.ReadEncoderValues();
   try {
-    const std::optional<MotorDriver::Encoders> encoders = motor_driver_.ReadEncoderValues();
-    left_wheel_.enc_ = (*encoders)[0];
-    right_wheel_.enc_ = (*encoders)[1];
+    const std::optional<MotorDriver::HardwareData> hardware_data = motor_driver_.ReadHardwareData();
+    left_wheel_.enc_ = (*hardware_data)[0];
+    right_wheel_.enc_ = (*hardware_data)[1];
+
+    // Convert int (0/1) to double since the state interface expects a double for the position.
+    left_bumper_ = static_cast<double>((*hardware_data)[2]);
+    right_bumper_ = static_cast<double>((*hardware_data)[3]);
+    button_ = static_cast<double>((*hardware_data)[4]);
   } catch (const std::exception& e) {
-    RCLCPP_ERROR(logger_, "Exception while reading encoder values: %s", e.what());
+    RCLCPP_ERROR(logger_, "Exception while reading hardware data: %s", e.what());
     return hardware_interface::return_type::OK;
   }
 

--- a/kimchi_base/src/motor_driver.cpp
+++ b/kimchi_base/src/motor_driver.cpp
@@ -63,18 +63,36 @@ bool MotorDriver::is_connected() const { return serial_port_.IsOpen(); }
 
 void MotorDriver::SendEmptyMsg() { std::string response = SendMsg(""); }
 
-std::optional<MotorDriver::Encoders> MotorDriver::ReadEncoderValues() {
-  std::optional<Encoders> output;
+std::optional<MotorDriver::HardwareData> MotorDriver::ReadHardwareData() {
+  std::optional<HardwareData> output;
 
   static const std::string delimiter = " ";
 
-  const std::string response = SendMsg("e");
+  // Send the command to read the hardware data.
+  const std::string response = SendMsg("h");
 
-  const size_t del_pos = response.find(delimiter);
-  const std::string token_1 = response.substr(0, del_pos).c_str();
-  const std::string token_2 = response.substr(del_pos + delimiter.length()).c_str();
+  const size_t del_pos_1 = response.find(delimiter);
+  const size_t del_pos_2 = response.find(delimiter, del_pos_1 + delimiter.length());
+  const size_t del_pos_3 = response.find(delimiter, del_pos_2 + delimiter.length());
+  const size_t del_pos_4 = response.find(delimiter, del_pos_3 + delimiter.length());
+  
+  // Check if all delimiters were found
+  if (del_pos_1 == std::string::npos || del_pos_2 == std::string::npos || del_pos_3 == std::string::npos ||
+      del_pos_4 == std::string::npos) {
+      std::cerr << "Error: Not enough delimiters found in response" << std::endl;
+      return std::nullopt;
+  }
 
-  size_t pos1, pos2;
+  const std::string token_1 = response.substr(0, del_pos_1);
+  const std::string token_2 = response.substr(del_pos_1 + delimiter.length(), 
+                                            del_pos_2 - del_pos_1 - delimiter.length());
+  const std::string token_3 = response.substr(del_pos_2 + delimiter.length(), 
+                                            del_pos_3 - del_pos_2 - delimiter.length());
+  const std::string token_4 = response.substr(del_pos_3 + delimiter.length(), 
+                                            del_pos_4 - del_pos_3 - delimiter.length());
+  const std::string token_5 = response.substr(del_pos_4 + delimiter.length());
+
+  size_t pos1, pos2, pos3, pos4, pos5;
   int left_encoder_value = std::stoi(token_1, &pos1);
   if (pos1 != token_1.length()) {
     std::cerr << "Error parsing token_1: " << token_1 << std::endl;
@@ -82,14 +100,35 @@ std::optional<MotorDriver::Encoders> MotorDriver::ReadEncoderValues() {
   }
 
   int right_encoder_value = std::stoi(token_2, &pos2);
-  // -2 because of /r/n
-  if (pos2 != token_2.length() - 2) {
+  if(pos2 != token_2.length()) {
     std::cerr << "Error parsing token_2: " << token_2 << std::endl;
     std::cerr << "pos2: " << pos2 << "token_2.length(): " << token_2.length() << std::endl;
     return std::nullopt;
   }
 
-  output = Encoders{left_encoder_value, right_encoder_value};
+  int left_bumper_value = std::stoi(token_3, &pos3);
+  if(pos3 != token_3.length()) {
+    std::cerr << "Error parsing token_3: " << token_3 << std::endl;
+    std::cerr << "pos3: " << pos3 << "token_3.length(): " << token_3.length() << std::endl;
+    return std::nullopt;
+  }
+
+  int right_bumper_value = std::stoi(token_4, &pos4);
+  if(pos4 != token_4.length()) {
+    std::cerr << "Error parsing token_4: " << token_4 << std::endl;
+    std::cerr << "pos4: " << pos4 << "token_4.length(): " << token_4.length() << std::endl;
+    return std::nullopt;
+  } 
+
+  int button_value = std::stoi(token_5, &pos5);
+  // -2 because of /r/n
+  if(pos5 != token_5.length() - 2) {
+    std::cerr << "Error parsing token_5: " << token_5 << std::endl;
+    std::cerr << "pos5: " << pos5 << "token_5.length(): " << token_5.length() << std::endl;
+    return std::nullopt;
+  } 
+
+  output = HardwareData{left_encoder_value, right_encoder_value, left_bumper_value, right_bumper_value, button_value};
   return output;
 }
 

--- a/kimchi_control/README.md
+++ b/kimchi_control/README.md
@@ -58,5 +58,8 @@ Two controllers are being used from the available [ros2_controllers](https://con
     - Used state interfaces:
       - left wheel position
       - right wheel position
+      - left bumper position
+      - right bumper position
+      - button position
 
 Each controller accepts ROS 2 parameters which they are provided via [`kimchi_controllers.yaml`](config/kimchi_controllers.yaml). 

--- a/kimchi_description/config/kimchi/hardware.yaml
+++ b/kimchi_description/config/kimchi/hardware.yaml
@@ -1,5 +1,8 @@
 left_wheel_name: left_wheel_joint
 right_wheel_name: right_wheel_joint
+left_bumper_name: left_bumper_joint
+right_bumper_name: right_bumper_joint
+button_name: button_joint
 serial_device: /dev/ttyUSB_ARDUINO
 baud_rate: 57600
 timeout: 1000

--- a/kimchi_description/urdf/include/common_sensors.urdf.xacro
+++ b/kimchi_description/urdf/include/common_sensors.urdf.xacro
@@ -46,6 +46,34 @@
     <axis xyz="0 1 0" />
   </joint>
 
+</xacro:macro>
+
+<!-- Bumpers and button -->
+<xacro:macro name="digital_sensors" params="parent_link hardware_props">
+
+  <!-- Left Bumper -->
+  <link name="${hardware_props['left_bumper_name']}_link"/>
+
+  <joint name="${hardware_props['left_bumper_name']}" type="continuous">
+    <parent link="${parent_link}"/>
+    <child link="${hardware_props['left_bumper_name']}_link"/>
+  </joint>
+
+  <!-- Right Bumper -->
+  <link name="${hardware_props['right_bumper_name']}_link"/>
+
+  <joint name="${hardware_props['right_bumper_name']}" type="continuous">
+    <parent link="${parent_link}"/>
+    <child link="${hardware_props['right_bumper_name']}_link"/>
+  </joint>
+
+  <!-- Button -->
+  <link name="${hardware_props['button_name']}_link"/>
+
+  <joint name="${hardware_props['button_name']}" type="continuous">
+    <parent link="${parent_link}"/>
+    <child link="${hardware_props['button_name']}_link"/>
+  </joint>
 
 </xacro:macro>
 

--- a/kimchi_description/urdf/include/kimchi_control.urdf.xacro
+++ b/kimchi_description/urdf/include/kimchi_control.urdf.xacro
@@ -16,6 +16,9 @@
         <plugin>kimchi_base/DiffDriveKimchi</plugin>
         <param name="left_wheel_name">${hardware_props['left_wheel_name']}</param>
         <param name="right_wheel_name">${hardware_props['right_wheel_name']}</param>
+        <param name="left_bumper_name">${hardware_props['left_bumper_name']}</param>
+        <param name="right_bumper_name">${hardware_props['right_bumper_name']}</param>
+        <param name="button_name">${hardware_props['button_name']}</param>
         <param name="serial_device">${hardware_props['serial_device']}</param>
         <param name="baud_rate">${hardware_props['baud_rate']}</param>
         <param name="timeout">${hardware_props['timeout']}</param>
@@ -35,6 +38,16 @@
           <param name="max">5</param>
         </command_interface>
         <state_interface name="velocity"/>
+        <state_interface name="position"/>
+      </joint>
+      <!-- Bumpers and button -->
+      <joint name="${hardware_props['left_bumper_name']}">
+        <state_interface name="position"/>
+      </joint>
+      <joint name="${hardware_props['right_bumper_name']}">
+        <state_interface name="position"/>
+      </joint>
+      <joint name="${hardware_props['button_name']}">
         <state_interface name="position"/>
       </joint>
     </ros2_control>

--- a/kimchi_description/urdf/kimchi.urdf.xacro
+++ b/kimchi_description/urdf/kimchi.urdf.xacro
@@ -67,6 +67,8 @@
   <xacro:if value="$(arg use_real_ros_control)">
     <xacro:include filename="$(find ${package_name})/urdf/include/kimchi_control.urdf.xacro" />
     <xacro:control hardware_props="${hardware_props}" />
+    <!-- Bumper and button -->
+    <xacro:digital_sensors parent_link="base_link" hardware_props="${hardware_props}" />
   </xacro:if>
 
 </robot>

--- a/kimchi_state/CMakeLists.txt
+++ b/kimchi_state/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(rclcpp_action REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
@@ -31,6 +32,7 @@ ament_target_dependencies(kimchi_state_server PUBLIC
   "rclcpp_components"
   "std_msgs"
   "geometry_msgs"
+  "sensor_msgs"
   "kimchi_interfaces"
   "std_srvs"
   "nav2_msgs"

--- a/kimchi_state/include/kimchi_state/kimchi_state_server.h
+++ b/kimchi_state/include/kimchi_state/kimchi_state_server.h
@@ -17,6 +17,7 @@
 #include <nav2_msgs/srv/save_map.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
 #include <std_msgs/msg/empty.hpp>
 #include <std_msgs/msg/int32.hpp>
 #include <std_srvs/srv/trigger.hpp>
@@ -101,6 +102,8 @@ class KimchiStateServer
           request,
       kimchi_interfaces::srv::KimchiStateServerCommand::Response::SharedPtr
           response);
+      kimchi_interfaces::srv::AddGoalToMission::Response::SharedPtr response);
+  void jointStatesCallback(const sensor_msgs::msg::JointState::SharedPtr msg);
 
   std::shared_ptr<rclcpp::Node> node_;
   std::unique_ptr<NavigationManager> navigation_manager_;
@@ -113,6 +116,7 @@ class KimchiStateServer
   rclcpp::TimerBase::SharedPtr state_publisher_timer_;
   rclcpp::Publisher<kimchi_interfaces::msg::RobotState>::SharedPtr
       state_publisher_;
+  rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_states_subscriber_;
 
   // Service servers.
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr start_slam_service_;
@@ -128,4 +132,9 @@ class KimchiStateServer
   rclcpp::Client<nav2_msgs::srv::SaveMap>::SharedPtr save_map_client_;
   rclcpp::Client<kimchi_interfaces::srv::MapInfo>::SharedPtr
       get_map_info_client_;
+
+  // Variables for bumpers and button.
+  bool left_bumper_state_ = false;
+  bool right_bumper_state_ = false;
+  bool button_state_ = false;
 };

--- a/kimchi_state/include/kimchi_state/kimchi_state_server.h
+++ b/kimchi_state/include/kimchi_state/kimchi_state_server.h
@@ -102,7 +102,6 @@ class KimchiStateServer
           request,
       kimchi_interfaces::srv::KimchiStateServerCommand::Response::SharedPtr
           response);
-      kimchi_interfaces::srv::AddGoalToMission::Response::SharedPtr response);
   void jointStatesCallback(const sensor_msgs::msg::JointState::SharedPtr msg);
 
   std::shared_ptr<rclcpp::Node> node_;

--- a/kimchi_state/package.xml
+++ b/kimchi_state/package.xml
@@ -14,6 +14,7 @@
   <depend>std_srvs</depend>
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
   <depend>kimchi_interfaces</depend>
   <depend>kimchi_navigation</depend>
   <depend>lifecycle_msgs</depend>

--- a/kimchi_state/src/kimchi_state_server.cpp
+++ b/kimchi_state/src/kimchi_state_server.cpp
@@ -125,6 +125,11 @@ void KimchiStateServer::initialize() {
           "/kimchi_state_server/send_command",
           std::bind(&KimchiStateServer::sendCommandCallback, this,
                     std::placeholders::_1, std::placeholders::_2));
+  joint_states_subscriber_ = node_->create_subscription<sensor_msgs::msg::JointState>(
+      "/joint_states", 10,
+      std::bind(&KimchiStateServer::jointStatesCallback, this,
+                std::placeholders::_1));
+
   // Call the map info service
   callGetMapInfoService();
 }
@@ -312,6 +317,32 @@ void KimchiStateServer::changeState(RobotState new_state) {
   state_ = new_state;
   RCLCPP_INFO(node_->get_logger(), "State changed to: %s",
               toString(state_).c_str());
+}
+
+// TODO(lneumarkt): Implement behavior based on bumper and button states
+void KimchiStateServer::jointStatesCallback(
+  const sensor_msgs::msg::JointState::SharedPtr msg) {
+
+  for (size_t i = 0; i < msg->name.size(); ++i) {
+    const std::string& joint_name = msg->name[i];
+    
+    // For all three joints, we consider a position of non-zero as "pressed"
+    if (joint_name == "button_joint") {
+      button_state_ = msg->position[i] > 0.01;
+      RCLCPP_DEBUG(node_->get_logger(), "Button state: %s", 
+                  button_state_ ? "PRESSED" : "NOT_PRESSED");
+    }
+    else if (joint_name == "left_bumper_joint") {
+      left_bumper_state_ = msg->position[i] > 0.01;
+      RCLCPP_DEBUG(node_->get_logger(), "Left bumper state: %s", 
+                  left_bumper_state_ ? "PRESSED" : "NOT_PRESSED");
+    }
+    else if (joint_name == "right_bumper_joint") {
+      right_bumper_state_ = msg->position[i] > 0.01;
+      RCLCPP_DEBUG(node_->get_logger(), "Right bumper state: %s", 
+                  right_bumper_state_ ? "PRESSED" : "NOT_PRESSED");
+    }
+  }
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
Add bumper and button behavior to ROS.

The Arduino now publishes bumper and button values over the serial link along with encoder data. These states are parsed on the ROS side and included in the existing joint_states publisher.

While pressed, the bumpers and buttons values will turn from 0.0 to 1.0
```
ros2 topic echo /joint_states

header:
  stamp:
    sec: 1755359911
    nanosec: 468402071
  frame_id: ''
name:
- button_joint
- left_bumper_joint
- left_wheel_joint
- right_bumper_joint
- right_wheel_joint
position:
- 1.0
- 0.0
- 165312.496510
- 0.0
- 151303.946135
```
