### PR TITLE
Fix docker

### DIFF
--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -39,10 +39,10 @@ RUN . /opt/ros/jazzy/setup.sh && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Re
 RUN echo "source /home/$USER/ros_deps_ws/install/setup.bash" >> /home/$USER/.bashrc
 
 # Add the Gazebo repository and install Gazebo Harmonic
-RUN sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" > /etc/apt/sources.list.d/gazebo-stable.list' && \
-    wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg && \
-    sudo apt update && \
-    sudo apt install -y gz-harmonic
+RUN sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+RUN wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+RUN sudo apt-get update
+RUN sudo apt-get install gz-harmonic -y
 
 # Create a user with passwordless sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -71,7 +71,7 @@ while [[ "$#" -gt 0 ]]; do
         -i|--image_name) IMAGE_NAME="${2}"; shift ;;
         -c|--container_name) CONTAINER_NAME="${2}"; shift ;;
         -h|--help) show_help ; exit 1 ;;
-        --use_nvidia) NVIDIA_FLAGS="--gpus=all -e NVIDIA_DRIVER_CAPABILITIES=all" ;;
+        --use_nvidia) NVIDIA_FLAGS="--gpus=all -e NVIDIA_DRIVER_CAPABILITIES=all --runtime=nvidia" ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift


### PR DESCRIPTION
- Gazebo installation has changed: https://gazebosim.org/docs/harmonic/install_ubuntu/#binary-installation-on-ubuntu
- Adding flag --runtime=nvidia as per: https://github.com/gazebosim/gz-sim/issues/3024#issuecomment-3205261916

## Test it

Build the docker container again:

```
./docker/buind.sh
```

Run the container:

```
./docker/run.sh --use_nvidia
```

Inside the docker open the simulation, state server and grpc. Check that everything works

