### PR TITLE
Adds feature to let the robot localize automatically after finishing a map

### DIFF
--- a/kimchi_state/include/kimchi_state/kimchi_state_server.h
+++ b/kimchi_state/include/kimchi_state/kimchi_state_server.h
@@ -21,8 +21,11 @@
 #include <std_msgs/msg/empty.hpp>
 #include <std_msgs/msg/int32.hpp>
 #include <std_srvs/srv/trigger.hpp>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
 
 #include "map_info.h"
+#include "point_2d.h"
 #include "navigation_manager.h"
 
 enum class RobotState {
@@ -54,6 +57,7 @@ class KimchiStateServer
   }
 
   // MissionObserver implemented methods.
+  void onNav2LocalizationStarted() override;
   void onNavigatingToGoal(const Point2D& point) override;
   void onGoalReached(const Point2D& point) override;
   void onMissionFinished() override;
@@ -72,6 +76,8 @@ class KimchiStateServer
    * be passed to it.
    */
   void initialize();
+
+  void startLocating(const Point2D& point);
 
   void statePublisherTimerCallback();
   void callGetMapInfoService();
@@ -103,6 +109,7 @@ class KimchiStateServer
       kimchi_interfaces::srv::KimchiStateServerCommand::Response::SharedPtr
           response);
   void jointStatesCallback(const sensor_msgs::msg::JointState::SharedPtr msg);
+  void getRobotPositionFromTF();
 
   std::shared_ptr<rclcpp::Node> node_;
   std::unique_ptr<NavigationManager> navigation_manager_;
@@ -132,8 +139,13 @@ class KimchiStateServer
   rclcpp::Client<kimchi_interfaces::srv::MapInfo>::SharedPtr
       get_map_info_client_;
 
+  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  rclcpp::TimerBase::SharedPtr tf_timer_;
+
   // Variables for bumpers and button.
   bool left_bumper_state_ = false;
   bool right_bumper_state_ = false;
   bool button_state_ = false;
+  Point2D current_robot_position_;
 };

--- a/kimchi_state/include/kimchi_state/navigation_manager.h
+++ b/kimchi_state/include/kimchi_state/navigation_manager.h
@@ -27,7 +27,9 @@ class NavigationManager {
    */
   class MissionObserver {
    public:
-    /**
+    virtual void onNav2LocalizationStarted() = 0;
+
+   /**
      * Called when the robot starts a new mission.
      * @param path The initial path for the mission.
      */
@@ -92,6 +94,8 @@ class NavigationManager {
       GoalHandleNavigateToPose::SharedPtr goal_handle);
   void navigateToPoseResultCallback(
       const GoalHandleNavigateToPose::WrappedResult& result);
+
+  void startNav2Localization();
 
   std::shared_ptr<rclcpp::Node> node_;
   std::shared_ptr<MissionObserver> mission_observer_;

--- a/kimchi_state/package.xml
+++ b/kimchi_state/package.xml
@@ -11,6 +11,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
   <depend>std_srvs</depend>
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/kimchi_state/src/kimchi_state_server.cpp
+++ b/kimchi_state/src/kimchi_state_server.cpp
@@ -229,12 +229,6 @@ void KimchiStateServer::initialPoseCallback(
     return;
   }
 
-  // changeState(RobotState::LOCATING);
-  // std::thread locate_thread([this, request]() {
-  //   navigation_manager_->startLocating(
-  //       Point2D(request->goal.x, request->goal.y));
-  // });
-  // locate_thread.detach();
   startLocating(Point2D(request->goal.x, request->goal.y));
   response->success = true;
 
@@ -278,7 +272,6 @@ void KimchiStateServer::startNavigationCallback(
 
 void KimchiStateServer::startNavigation() {
   navigation_manager_->startNavigation();
-  // changeState(RobotState::LOST);
 }
 
 void KimchiStateServer::sendCommandCallback(

--- a/kimchi_state/src/kimchi_state_server.cpp
+++ b/kimchi_state/src/kimchi_state_server.cpp
@@ -10,6 +10,10 @@
 #include <thread>
 
 #include "rclcpp/wait_for_message.hpp"
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <tf2/exceptions.h>
 
 namespace {
 std::string toString(RobotState robot_state) {
@@ -47,6 +51,16 @@ std::shared_ptr<KimchiStateServer> KimchiStateServer::Create(
       std::shared_ptr<KimchiStateServer>(new KimchiStateServer(options));
   output->initialize();
   return output;
+}
+
+void KimchiStateServer::onNav2LocalizationStarted() {
+  RCLCPP_INFO(node_->get_logger(), "[KimchiStateServer] Localization started");
+  if (state_ == RobotState::MAPPING_WITH_EXPLORATION ||
+      state_ == RobotState::MAPPING_WITH_TELEOP) {
+   startLocating(current_robot_position_);
+  } else {
+    changeState(RobotState::LOST);
+  }
 }
 
 void KimchiStateServer::onNavigatingToGoal(const Point2D &point) {
@@ -130,6 +144,15 @@ void KimchiStateServer::initialize() {
       std::bind(&KimchiStateServer::jointStatesCallback, this,
                 std::placeholders::_1));
 
+  // Initialize tf2 buffer and listener
+  tf_buffer_ = std::make_unique<tf2_ros::Buffer>(node_->get_clock());
+  tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+  
+  // Create a timer to periodically check the transform
+  tf_timer_ = node_->create_wall_timer(
+      std::chrono::milliseconds(1000),
+      std::bind(&KimchiStateServer::getRobotPositionFromTF, this));
+
   // Call the map info service
   callGetMapInfoService();
 }
@@ -138,7 +161,8 @@ KimchiStateServer::KimchiStateServer(
     const rclcpp::NodeOptions &options = rclcpp::NodeOptions())
     : node_(new rclcpp::Node("kimchi_state_server", options)),
       navigation_manager_(nullptr),
-      state_(RobotState::NO_MAP) {}
+      state_(RobotState::NO_MAP),
+      current_robot_position_{0.0, 0.0} {}
 
 void KimchiStateServer::statePublisherTimerCallback() {
   auto message = kimchi_interfaces::msg::RobotState();
@@ -205,15 +229,24 @@ void KimchiStateServer::initialPoseCallback(
     return;
   }
 
-  changeState(RobotState::LOCATING);
-  std::thread locate_thread([this, request]() {
-    navigation_manager_->startLocating(
-        Point2D(request->goal.x, request->goal.y));
-  });
-  locate_thread.detach();
+  // changeState(RobotState::LOCATING);
+  // std::thread locate_thread([this, request]() {
+  //   navigation_manager_->startLocating(
+  //       Point2D(request->goal.x, request->goal.y));
+  // });
+  // locate_thread.detach();
+  startLocating(Point2D(request->goal.x, request->goal.y));
   response->success = true;
 
   return;
+}
+
+void KimchiStateServer::startLocating(const Point2D& point) {
+  changeState(RobotState::LOCATING);
+  std::thread locate_thread([this, point]() {
+    navigation_manager_->startLocating(point);
+  });
+  locate_thread.detach();
 }
 
 void KimchiStateServer::startNavigationCallback(
@@ -245,7 +278,7 @@ void KimchiStateServer::startNavigationCallback(
 
 void KimchiStateServer::startNavigation() {
   navigation_manager_->startNavigation();
-  changeState(RobotState::LOST);
+  // changeState(RobotState::LOST);
 }
 
 void KimchiStateServer::sendCommandCallback(
@@ -345,6 +378,28 @@ void KimchiStateServer::jointStatesCallback(
                   right_bumper_state_ ? "PRESSED" : "NOT_PRESSED");
     }
   }
+}
+
+void KimchiStateServer::getRobotPositionFromTF() {
+    std::string target_frame = "map";  // or "odom"
+    std::string source_frame = "base_link";
+    
+    try {
+        // Look up the transform from base_link to map
+        geometry_msgs::msg::TransformStamped transform_stamped = 
+            tf_buffer_->lookupTransform(
+                target_frame, 
+                source_frame,
+                tf2::TimePointZero);  // Get the latest available transform
+        
+        // Extract position
+        current_robot_position_.x = transform_stamped.transform.translation.x;
+        current_robot_position_.y = transform_stamped.transform.translation.y;
+    } catch (const tf2::TransformException& ex) {
+        RCLCPP_WARN(node_->get_logger(), 
+            "Could not transform %s to %s: %s", 
+            source_frame.c_str(), target_frame.c_str(), ex.what());
+    }
 }
 
 int main(int argc, char *argv[]) {

--- a/kimchi_state/src/kimchi_state_server.cpp
+++ b/kimchi_state/src/kimchi_state_server.cpp
@@ -374,7 +374,7 @@ void KimchiStateServer::jointStatesCallback(
 }
 
 void KimchiStateServer::getRobotPositionFromTF() {
-    std::string target_frame = "map";  // or "odom"
+    std::string target_frame = "map";
     std::string source_frame = "base_link";
     
     try {

--- a/kimchi_state/src/navigation_manager.cpp
+++ b/kimchi_state/src/navigation_manager.cpp
@@ -64,13 +64,23 @@ void NavigationManager::startNavigation() {
     std::this_thread::sleep_for(wait_duration);
   }
 
+  // std::thread startup_loc_thread(
+  //     std::bind(&nav2_lifecycle_manager::LifecycleManagerClient::startup,
+  //               client_localization_.get(), std::placeholders::_1),
+  //     wait_duration  // Direct argument instead of placeholder
+  // );
   std::thread startup_loc_thread(
-      std::bind(&nav2_lifecycle_manager::LifecycleManagerClient::startup,
-                client_localization_.get(), std::placeholders::_1),
+      std::bind(&NavigationManager::startNav2Localization,
+                this),
       wait_duration  // Direct argument instead of placeholder
   );
 
   startup_loc_thread.detach();
+}
+void NavigationManager::startNav2Localization() {
+  std::chrono::milliseconds wait_duration(100);
+  client_localization_->startup(wait_duration);
+  mission_observer_->onNav2LocalizationStarted();
 }
 
 void NavigationManager::stopNavigation() {}

--- a/kimchi_state/src/navigation_manager.cpp
+++ b/kimchi_state/src/navigation_manager.cpp
@@ -64,11 +64,6 @@ void NavigationManager::startNavigation() {
     std::this_thread::sleep_for(wait_duration);
   }
 
-  // std::thread startup_loc_thread(
-  //     std::bind(&nav2_lifecycle_manager::LifecycleManagerClient::startup,
-  //               client_localization_.get(), std::placeholders::_1),
-  //     wait_duration  // Direct argument instead of placeholder
-  // );
   std::thread startup_loc_thread(
       std::bind(&NavigationManager::startNav2Localization,
                 this),


### PR DESCRIPTION
Adds automatic localization after finishing mapping. 

- Subscribes the state server to TF to get the position of the robot
- When the map finishes and localization is initialized, if the last state was mapping, uses the saved position to call the localization action.

## Test it

### Prerequisites

- Get the last version of the [mobile app](https://github.com/Kimchi-Robotics/mobile-app)
- Start without a map: `rm kimchi_map.*`

### Steps

- Terminal 1: Run the simulation 
```
ros2 launch andino_gz andino_gz.launch.py nav2:=False rviz:=False world_name:=populated_office.sdf 
```
-  Terminal 2: Launch the kimchi state server
```
ros2 launch kimchi_state kimchi_state_server.launch.py
```
- Terminal 3: Launch the grpc server
```
ros2 launch kimchi_grpc_server kimchi_grpc_server.launch.py
```
- Create a map
- Touch the "Finalizar" button.
- Watch the robot autolocalizing after navigation is initialized.


https://github.com/user-attachments/assets/ccad1d43-4410-4185-83fd-b8bcd93b64a8


