### PR TITLE
Update dockerfile to avoid user id collision

### DIFF
--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -31,8 +31,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         adduser $USER sudo && \
         echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers; \
     else \
-        # If no user has the conflicting UID, do nothing.
-        echo "No user with UID $USERID found. No changes needed."; \
+        RUN adduser --uid $USERID --gecos "ekumen developer" --disabled-password $USER
+        RUN adduser $USER sudo
+        RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
     fi
 RUN echo "export QT_X11_NO_MITSHM=1" >> /home/$USER/.bashrc
 RUN echo "export IGN_IP=127.0.0.1" >> /home/$USER/.bashrc


### PR DESCRIPTION
This PR introduces a change on the dockerfile to avoid having an user id collision between the local user id and Ubuntu's user id in ROS2. 

The default user id in Linux is defined as `1000` and inside ros-jazzy container ubuntu's user id is also `1000` which generates a collision: 
 
![WhatsApp Image 2025-05-11 at 19 47 17](https://github.com/user-attachments/assets/b2c40121-f934-41b7-8777-d546820b29fa)

Whith this change  the existing user (ros, UID 1000) is modified to match the host user.