### PR TITLE
Add functionality to detect if the robot was kidnapped

### DIFF
--- a/kimchi_state/include/kimchi_state/kimchi_state_server.h
+++ b/kimchi_state/include/kimchi_state/kimchi_state_server.h
@@ -122,6 +122,16 @@ class KimchiStateServer
   void jointStatesCallback(const sensor_msgs::msg::JointState::SharedPtr msg);
   void getRobotPositionFromTF();
 
+    /**
+   * AMCL pose callback
+   * Callback method for pose published by AMCL.
+   *
+   * Verifies if the robot is localized by checking if the covariance of the
+   * estimated amcl pose is within a set threshold
+   */
+  void AmclPoseCallback(
+      const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg);
+
   std::shared_ptr<rclcpp::Node> node_;
   std::unique_ptr<NavigationManager> navigation_manager_;
   std::atomic<RobotState> state_;
@@ -134,6 +144,8 @@ class KimchiStateServer
   rclcpp::Publisher<kimchi_interfaces::msg::RobotState>::SharedPtr
       state_publisher_;
   rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_states_subscriber_;
+	rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
+			amcl_pose_subscription_;
 
   // Service servers.
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr start_slam_service_;

--- a/kimchi_state/src/kimchi_state_server.cpp
+++ b/kimchi_state/src/kimchi_state_server.cpp
@@ -161,6 +161,12 @@ void KimchiStateServer::initialize() {
       std::bind(&KimchiStateServer::jointStatesCallback, this,
                 std::placeholders::_1));
 
+  amcl_pose_subscription_ =
+      node_->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
+          "/amcl_pose", 10,
+          std::bind(&KimchiStateServer::AmclPoseCallback, this,
+                    std::placeholders::_1));
+
   // Initialize tf2 buffer and listener
   tf_buffer_ = std::make_unique<tf2_ros::Buffer>(node_->get_clock());
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
@@ -409,6 +415,27 @@ void KimchiStateServer::getRobotPositionFromTF() {
             "Could not transform %s to %s: %s", 
             source_frame.c_str(), target_frame.c_str(), ex.what());
     }
+}
+
+void KimchiStateServer::AmclPoseCallback(
+    const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg) {
+
+  double var_x = msg->pose.covariance[0];     // Variance in X position
+  double var_y = msg->pose.covariance[7];     // Variance in Y position
+  double var_yaw = msg->pose.covariance[35];  // Variance in Yaw orientation
+
+  // Calculate a combined position covariance (e.g., sum of squares)
+  double current_position_uncertainty = std::sqrt(var_x + var_y);
+  // For orientation, we directly use the yaw variance
+  double current_orientation_uncertainty = std::sqrt(var_yaw);
+
+  // Check if uncertainty of the pose is lower than the threshold
+  if (current_position_uncertainty > 0.5 &&
+      current_orientation_uncertainty > 0.1 && state_ == RobotState::IDLE) {
+    RCLCPP_INFO(node_->get_logger(),
+                "[GlobalLocalizationServer] Robot Kidnapped starting relocalization");
+    changeState(RobotState::LOST);
+  }
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
Add functionality to detect if the robot was kidnapped and sets the robot state to `LOST`. By doing this the system will ask the user to relocate the robot on the app. 

### Try it out

1. Initialize the robot stack:
`ros2 launch andino_gz andino_gz.launch.py nav2:=False rviz:=False world_name:=populated_office.sdf`
`ros2 launch kimchi_state kimchi_state_server.launch.py`
`ros2 launch kimchi_grpc_server kimchi_grpc_server.launch.py`
2. Localize the robot
3. On gazebo, move the robot manually, this should trigger AMCL lost status, which can be verified by looking at RViz and observing that the particles have been re-distributed on the map. This will also re-trigger the localization on the app:


https://github.com/user-attachments/assets/1ecd2cc9-2e22-4a87-90dd-2bcc3b8e4a99

[GazeboRviz.webm](https://github.com/user-attachments/assets/5f33a686-cbda-47f2-8b02-5aaf07142b6f)

