### PR TITLE
Fixes localization after mapping on real robot

### DIFF
--- a/kimchi_state/src/navigation_manager.cpp
+++ b/kimchi_state/src/navigation_manager.cpp
@@ -75,6 +75,12 @@ void NavigationManager::startNavigation() {
 void NavigationManager::startNav2Localization() {
   std::chrono::milliseconds wait_duration(100);
   client_localization_->startup(wait_duration);
+  while (client_localization_->is_active(std::chrono::nanoseconds(100000)) != 
+         nav2_lifecycle_manager::SystemStatus::ACTIVE) {
+    RCLCPP_INFO(node_->get_logger(),
+                "[NavigationManager] Waiting for lifecycle_manager_localization to be active");
+    std::this_thread::sleep_for(wait_duration);
+  }
   mission_observer_->onNav2LocalizationStarted();
 }
 


### PR DESCRIPTION
The global localization node was publishing the init pose before AMCL was initialized. That's why the robot kept rotating.

This PR makes the navigation manager wait until localization has started to tell that to the state server so it can call the global localization service.

## Test it (Both simulation and real robot)

1- From scratch

- Init the robot without a previous map
- Make a map
- Finish it
- Navigation should start and the robot should locate automatically

2- With a map

- Init the robot with a previous map
- When opening the app, it should tell you that the robot is lost and has to be localized
- Touch on the map to localize the robot
- The robot should localize